### PR TITLE
Fix "Requires main queue setup" warning

### DIFF
--- a/packages/react-native-version-check/ios/RNVersionCheck.m
+++ b/packages/react-native-version-check/ios/RNVersionCheck.m
@@ -3,6 +3,11 @@
 
 @implementation RNVersionCheck
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+    
 - (dispatch_queue_t)methodQueue
 {
     return dispatch_get_main_queue();


### PR DESCRIPTION
This fixes the warning in console which is produced by react-native-version-check@2.1.0 running with React Native 0.51 on iOS:
```
Module RNVersionCheck requires main queue setup since it overrides
`constantsToExport` but doesn't implement `requiresMainQueueSetup`. 
In a future release React Native will default to initializing all native modules on a 
background thread unless explicitly opted-out of.
```